### PR TITLE
Restrict sorting column names

### DIFF
--- a/app/Http/Livewire/DataTables.php
+++ b/app/Http/Livewire/DataTables.php
@@ -15,9 +15,14 @@ class DataTables extends Component
     public $sortField;
     public $sortAsc = true;
     protected $queryString = ['search', 'active', 'sortAsc', 'sortField'];
+    protected $sortingFields = ['name', 'email'];
 
     public function sortBy($field)
     {
+        if (!in_array($field, $this->sortingFields)) {
+            $field = '';
+        }
+
         if ($this->sortField === $field) {
             $this->sortAsc = !$this->sortAsc;
         } else {

--- a/tests/Feature/DataTablesTest.php
+++ b/tests/Feature/DataTablesTest.php
@@ -208,4 +208,12 @@ class DataTablesTest extends TestCase
             ->call('sortBy', 'email')
             ->assertSeeInOrder(['Cathy C', 'Brian B', 'Andre A']);
     }
+
+    /** @test */
+    public function only_allowed_sorting_fields()
+    {
+        Livewire::test(DataTables::class)
+            ->call('sortBy', 'not_a_field_in_the_list')
+            ->assertSet('sortField', '');
+    }
 }


### PR DESCRIPTION
We have to restrict users to choose a sorting column name from a specified list, otherwise it will throw an error when trying to run the query if the column name doesn't exist.